### PR TITLE
Handle case where paternal last name has no second vowel

### DIFF
--- a/lib/natural_person.ex
+++ b/lib/natural_person.ex
@@ -243,7 +243,7 @@ defmodule RfcFacil.NaturalPerson do
     {first_char, remainder} = String.next_grapheme(lastname)
 
     first_char <>
-      next_vowel(remainder) <>
+      paternal_surname_letter_2(remainder) <>
       String.slice(lastname2, 0, 1) <>
       String.slice(name, 0, 1)
   end
@@ -340,6 +340,18 @@ defmodule RfcFacil.NaturalPerson do
       number == 1 -> "A"
       number in [2, 11] -> to_string(11 - number)
       true -> to_string(11 - number)
+    end
+  end
+
+  # Regresa la siguiente vocal, o si no hay, la segunda letra
+  defp paternal_surname_letter_2(paternal_surname) do
+    vowel = next_vowel(paternal_surname)
+
+    if vowel do
+      vowel
+    else
+      {next_letter, _} = String.next_grapheme(paternal_surname)
+      next_letter
     end
   end
 

--- a/test/rfc_facil_test.exs
+++ b/test/rfc_facil_test.exs
@@ -40,6 +40,11 @@ defmodule RfcFacilTest do
     assert rfc == "OACR661121B47"
   end
 
+  test "calculate RFC for people with only one vowel in their paternal last name" do
+    {:ok, rfc} = RfcFacil.for_natural_person("Roberto", "Orff", "Carballo", "1966-11-21")
+    assert rfc == "ORCR661121IL0"
+  end
+
   test "calculate normal RFC" do
     {:ok, rfc} = RfcFacil.for_natural_person("Erick", "Madrid", "Cruz", "1989-03-09")
     assert rfc == "MACE890309659"


### PR DESCRIPTION
Fixes https://github.com/resuelve/rfc_facil/issues/9 issue where RFC generation fails if the paternal surname has no second vowel.

Based on [this](https://learn.sayari.com/mexico-tax-id-number-rfc/)

First letter and first internal vowel of the paternal surname
If the paternal surname does not have a first internal vowel, the second letter of the paternal surname is used.
If the person does not have a second surname, first two letters of the paternal surname are used.

If it's 👍 , I will PR this upstream.